### PR TITLE
Add expandable code blocks plugin

### DIFF
--- a/material/plugins/expand/__init__.py
+++ b/material/plugins/expand/__init__.py
@@ -1,0 +1,5 @@
+"""Expandable code blocks plugin."""
+
+from .plugin import ExpandPlugin
+
+__all__ = ["ExpandPlugin"]

--- a/material/plugins/expand/config.py
+++ b/material/plugins/expand/config.py
@@ -1,0 +1,8 @@
+from mkdocs.config.config_options import Type
+from mkdocs.config.base import Config
+
+
+class ExpandConfig(Config):
+    """Configuration for the expand plugin."""
+
+    enabled = Type(bool, default=True)

--- a/material/plugins/expand/plugin.py
+++ b/material/plugins/expand/plugin.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from mkdocs.plugins import BasePlugin
+
+from .config import ExpandConfig
+
+
+SCRIPT = """
+<script>
+document.addEventListener('DOMContentLoaded',function(){
+  document.querySelectorAll('pre > code').forEach(function(code){
+    const pre = code.parentElement;
+    if(pre.scrollWidth > pre.clientWidth){
+      const wrapper = document.createElement('div');
+      wrapper.className = 'md-code-expand';
+      pre.parentNode.insertBefore(wrapper, pre);
+      wrapper.appendChild(pre);
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'md-code-expand__toggle';
+      button.textContent = 'Expand';
+      button.addEventListener('click', function(){
+        wrapper.classList.toggle('expanded');
+        button.textContent = wrapper.classList.contains('expanded') ? 'Collapse' : 'Expand';
+      });
+      wrapper.appendChild(button);
+    }
+  });
+});
+</script>
+<style>
+.md-code-expand{position:relative;margin:0}
+.md-code-expand__toggle{position:absolute;top:4px;right:4px;font-size:.75em;cursor:pointer}
+.md-code-expand.expanded pre{max-width:none;width:auto}
+</style>
+"""
+
+
+class ExpandPlugin(BasePlugin[ExpandConfig]):
+    """MkDocs plugin to add expandable code blocks."""
+
+    def on_post_page(self, output: str, *, page, config) -> str:
+        if not self.config.enabled:
+            return output
+        if '</body>' in output:
+            return output.replace('</body>', SCRIPT + '</body>')
+        return output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ Funding = "https://github.com/sponsors/squidfunk"
 "material/offline" = "material.plugins.offline.plugin:OfflinePlugin"
 "material/privacy" = "material.plugins.privacy.plugin:PrivacyPlugin"
 "material/search" = "material.plugins.search.plugin:SearchPlugin"
+"material/expand" = "material.plugins.expand.plugin:ExpandPlugin"
 "material/social" = "material.plugins.social.plugin:SocialPlugin"
 "material/tags" = "material.plugins.tags.plugin:TagsPlugin"
 

--- a/src/plugins/expand/__init__.py
+++ b/src/plugins/expand/__init__.py
@@ -1,0 +1,5 @@
+"""Expandable code blocks plugin."""
+
+from .plugin import ExpandPlugin
+
+__all__ = ["ExpandPlugin"]

--- a/src/plugins/expand/config.py
+++ b/src/plugins/expand/config.py
@@ -1,0 +1,8 @@
+from mkdocs.config.config_options import Type
+from mkdocs.config.base import Config
+
+
+class ExpandConfig(Config):
+    """Configuration for the expand plugin."""
+
+    enabled = Type(bool, default=True)

--- a/src/plugins/expand/plugin.py
+++ b/src/plugins/expand/plugin.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from mkdocs.plugins import BasePlugin
+
+from .config import ExpandConfig
+
+
+SCRIPT = """
+<script>
+document.addEventListener('DOMContentLoaded',function(){
+  document.querySelectorAll('pre > code').forEach(function(code){
+    const pre = code.parentElement;
+    if(pre.scrollWidth > pre.clientWidth){
+      const wrapper = document.createElement('div');
+      wrapper.className = 'md-code-expand';
+      pre.parentNode.insertBefore(wrapper, pre);
+      wrapper.appendChild(pre);
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'md-code-expand__toggle';
+      button.textContent = 'Expand';
+      button.addEventListener('click', function(){
+        wrapper.classList.toggle('expanded');
+        button.textContent = wrapper.classList.contains('expanded') ? 'Collapse' : 'Expand';
+      });
+      wrapper.appendChild(button);
+    }
+  });
+});
+</script>
+<style>
+.md-code-expand{position:relative;margin:0}
+.md-code-expand__toggle{position:absolute;top:4px;right:4px;font-size:.75em;cursor:pointer}
+.md-code-expand.expanded pre{max-width:none;width:auto}
+</style>
+"""
+
+
+class ExpandPlugin(BasePlugin[ExpandConfig]):
+    """MkDocs plugin to add expandable code blocks."""
+
+    def on_post_page(self, output: str, *, page, config) -> str:
+        if not self.config.enabled:
+            return output
+        if '</body>' in output:
+            return output.replace('</body>', SCRIPT + '</body>')
+        return output


### PR DESCRIPTION
## Summary
- add `expand` plugin for expandable code blocks
- register plugin entry point

## Testing
- `npm run check`
- `npm run build`
- `python -m py_compile src/plugins/expand/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68528caa1f5083309f2887e7b591f950