### PR TITLE
Add expandable code plugin

### DIFF
--- a/material/plugins/expand/__init__.py
+++ b/material/plugins/expand/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2016-2025 Martin Donath <martin.donath@squidfunk.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.

--- a/material/plugins/expand/assets/expand.css
+++ b/material/plugins/expand/assets/expand.css
@@ -1,0 +1,4 @@
+pre.code-expandable{position:relative}
+.code-expand-button{position:absolute;top:.25rem;right:.25rem;background:var(--md-code-bg-color);color:var(--md-code-fg-color);border:none;cursor:pointer}
+.code-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:1000;padding:1rem;overflow:auto}
+.code-overlay pre{max-width:none}

--- a/material/plugins/expand/assets/expand.js
+++ b/material/plugins/expand/assets/expand.js
@@ -1,0 +1,23 @@
+document.addEventListener("DOMContentLoaded",()=>{
+  document.querySelectorAll("pre").forEach(pre=>{
+    if(pre.scrollWidth<=pre.clientWidth)return;
+    pre.classList.add("code-expandable");
+    const btn=document.createElement("button");
+    btn.type="button";
+    btn.className="code-expand-button";
+    btn.title="Expand";
+    btn.textContent="⇱";
+    btn.addEventListener("click",()=>showOverlay(pre));
+    pre.appendChild(btn);
+  });
+  function showOverlay(pre){
+    const overlay=document.createElement("div");
+    overlay.className="code-overlay";
+    const clone=pre.cloneNode(true);
+    const b=clone.querySelector(".code-expand-button");
+    if(b)b.remove();
+    overlay.appendChild(clone);
+    overlay.addEventListener("click",()=>overlay.remove());
+    document.body.appendChild(overlay);
+  }
+});

--- a/material/plugins/expand/config.py
+++ b/material/plugins/expand/config.py
@@ -1,0 +1,5 @@
+from mkdocs.config.config_options import Type
+from mkdocs.config.base import Config
+
+class ExpandConfig(Config):
+    enabled = Type(bool, default=True)

--- a/material/plugins/expand/plugin.py
+++ b/material/plugins/expand/plugin.py
@@ -1,0 +1,29 @@
+import os
+from mkdocs.plugins import BasePlugin
+from mkdocs.utils import copy_file
+
+from .config import ExpandConfig
+
+class ExpandPlugin(BasePlugin[ExpandConfig]):
+    JS_PATH = "assets/javascripts/expand.js"
+    CSS_PATH = "assets/stylesheets/expand.css"
+
+    def on_config(self, config):
+        if not self.config.enabled:
+            return
+        if self.JS_PATH not in config.extra_javascript:
+            config.extra_javascript.append(self.JS_PATH)
+        if self.CSS_PATH not in config.extra_css:
+            config.extra_css.append(self.CSS_PATH)
+
+    def on_post_build(self, *, config):
+        if not self.config.enabled:
+            return
+        src_dir = os.path.join(os.path.dirname(__file__), "assets")
+        files = [
+            (os.path.join(src_dir, "expand.js"), os.path.join(config.site_dir, self.JS_PATH)),
+            (os.path.join(src_dir, "expand.css"), os.path.join(config.site_dir, self.CSS_PATH)),
+        ]
+        for src, dest in files:
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            copy_file(src, dest)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ Funding = "https://github.com/sponsors/squidfunk"
 "material/search" = "material.plugins.search.plugin:SearchPlugin"
 "material/social" = "material.plugins.social.plugin:SocialPlugin"
 "material/tags" = "material.plugins.tags.plugin:TagsPlugin"
+"material/expand" = "material.plugins.expand.plugin:ExpandPlugin"
 
 [project.entry-points."mkdocs.themes"]
 material = "material.templates"

--- a/src/plugins/expand/__init__.py
+++ b/src/plugins/expand/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2016-2025 Martin Donath <martin.donath@squidfunk.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.

--- a/src/plugins/expand/assets/expand.css
+++ b/src/plugins/expand/assets/expand.css
@@ -1,0 +1,4 @@
+pre.code-expandable{position:relative}
+.code-expand-button{position:absolute;top:.25rem;right:.25rem;background:var(--md-code-bg-color);color:var(--md-code-fg-color);border:none;cursor:pointer}
+.code-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:1000;padding:1rem;overflow:auto}
+.code-overlay pre{max-width:none}

--- a/src/plugins/expand/assets/expand.js
+++ b/src/plugins/expand/assets/expand.js
@@ -1,0 +1,23 @@
+document.addEventListener("DOMContentLoaded",()=>{
+  document.querySelectorAll("pre").forEach(pre=>{
+    if(pre.scrollWidth<=pre.clientWidth)return;
+    pre.classList.add("code-expandable");
+    const btn=document.createElement("button");
+    btn.type="button";
+    btn.className="code-expand-button";
+    btn.title="Expand";
+    btn.textContent="⇱";
+    btn.addEventListener("click",()=>showOverlay(pre));
+    pre.appendChild(btn);
+  });
+  function showOverlay(pre){
+    const overlay=document.createElement("div");
+    overlay.className="code-overlay";
+    const clone=pre.cloneNode(true);
+    const b=clone.querySelector(".code-expand-button");
+    if(b)b.remove();
+    overlay.appendChild(clone);
+    overlay.addEventListener("click",()=>overlay.remove());
+    document.body.appendChild(overlay);
+  }
+});

--- a/src/plugins/expand/config.py
+++ b/src/plugins/expand/config.py
@@ -1,0 +1,5 @@
+from mkdocs.config.config_options import Type
+from mkdocs.config.base import Config
+
+class ExpandConfig(Config):
+    enabled = Type(bool, default=True)

--- a/src/plugins/expand/plugin.py
+++ b/src/plugins/expand/plugin.py
@@ -1,0 +1,29 @@
+import os
+from mkdocs.plugins import BasePlugin
+from mkdocs.utils import copy_file
+
+from .config import ExpandConfig
+
+class ExpandPlugin(BasePlugin[ExpandConfig]):
+    JS_PATH = "assets/javascripts/expand.js"
+    CSS_PATH = "assets/stylesheets/expand.css"
+
+    def on_config(self, config):
+        if not self.config.enabled:
+            return
+        if self.JS_PATH not in config.extra_javascript:
+            config.extra_javascript.append(self.JS_PATH)
+        if self.CSS_PATH not in config.extra_css:
+            config.extra_css.append(self.CSS_PATH)
+
+    def on_post_build(self, *, config):
+        if not self.config.enabled:
+            return
+        src_dir = os.path.join(os.path.dirname(__file__), "assets")
+        files = [
+            (os.path.join(src_dir, "expand.js"), os.path.join(config.site_dir, self.JS_PATH)),
+            (os.path.join(src_dir, "expand.css"), os.path.join(config.site_dir, self.CSS_PATH)),
+        ]
+        for src, dest in files:
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            copy_file(src, dest)


### PR DESCRIPTION
## Summary
- implement `ExpandPlugin` to allow expandable code blocks
- bundle plugin assets and register entry point

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68528caa1f5083309f2887e7b591f950