### PR TITLE
Add expandable code block plugin

### DIFF
--- a/docs/plugins/expand.md
+++ b/docs/plugins/expand.md
@@ -1,0 +1,17 @@
+---
+title: Expandable code blocks plugin
+icon: material/arrow-expand
+---
+
+# Expandable code blocks plugin
+
+This plugin adds a small button to code blocks that overflow the content area. Clicking the button expands the block to its full width so long lines become readable. Clicking again collapses the block.
+
+## Configuration
+
+``` yaml
+plugins:
+  - expand
+```
+
+The plugin is built into the theme, so no additional installation is required.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -240,6 +240,7 @@ nav:
     - Privacy: plugins/privacy.md
     - Projects: plugins/projects.md
     - Search: plugins/search.md
+    - Expand: plugins/expand.md
     - Social: plugins/social.md
     - Tags: plugins/tags.md
     - Typeset: plugins/typeset.md

--- a/src/plugins/expand/__init__.py
+++ b/src/plugins/expand/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2016-2025 Martin Donath <martin.donath@squidfunk.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.

--- a/src/plugins/expand/config.py
+++ b/src/plugins/expand/config.py
@@ -1,0 +1,6 @@
+from mkdocs.config.config_options import Type
+from mkdocs.config.base import Config
+
+# Expand plugin configuration
+class ExpandConfig(Config):
+    enabled = Type(bool, default=True)

--- a/src/plugins/expand/plugin.py
+++ b/src/plugins/expand/plugin.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2016-2025 Martin Donath <martin.donath@squidfunk.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+from __future__ import annotations
+
+import os
+
+from mkdocs.plugins import BasePlugin
+
+from .config import ExpandConfig
+
+_JS = """
+(function() {
+  function init() {
+    document.querySelectorAll('pre').forEach(function(pre) {
+      if (pre.scrollWidth > pre.clientWidth) {
+        pre.classList.add('md-expand');
+        var btn = document.createElement('button');
+        btn.className = 'md-expand-button';
+        btn.type = 'button';
+        btn.textContent = 'Expand';
+        btn.onclick = function() {
+          pre.classList.toggle('md-expanded');
+          btn.textContent = pre.classList.contains('md-expanded') ? 'Collapse' : 'Expand';
+        };
+        pre.appendChild(btn);
+      }
+    });
+  }
+  if (document.readyState !== 'loading') init();
+  else document.addEventListener('DOMContentLoaded', init);
+})();
+"""
+
+_CSS = """
+.md-expand {
+  position: relative;
+  overflow: auto;
+}
+.md-expand-button {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  font-size: 0.75rem;
+  background: var(--md-default-bg-color);
+  border: 1px solid var(--md-default-fg-color--lighter);
+  border-radius: 2px;
+  cursor: pointer;
+}
+.md-expand.md-expanded {
+  width: max-content;
+  max-width: none;
+}
+"""
+
+
+class ExpandPlugin(BasePlugin[ExpandConfig]):
+
+    def on_config(self, config):
+        if not self.config.enabled:
+            return
+
+        self.dest_dir = os.path.join('assets', 'expand')
+        js = os.path.join(self.dest_dir, 'expand.js')
+        css = os.path.join(self.dest_dir, 'expand.css')
+        if js not in config.extra_javascript:
+            config.extra_javascript.append(js)
+        if css not in config.extra_css:
+            config.extra_css.append(css)
+
+    def on_post_build(self, *, config):
+        if not self.config.enabled:
+            return
+
+        dest = os.path.join(config.site_dir, self.dest_dir)
+        os.makedirs(dest, exist_ok=True)
+        with open(os.path.join(dest, 'expand.js'), 'w', encoding='utf-8') as f:
+            f.write(_JS)
+        with open(os.path.join(dest, 'expand.css'), 'w', encoding='utf-8') as f:
+            f.write(_CSS)


### PR DESCRIPTION
## Summary
- add new `expand` plugin to provide expandable code blocks
- document the new plugin
- include new plugin in docs navigation

## Testing
- `npm run check`
- `npm run build`
- `mkdocs build` *(fails: cannot find module 'material.extensions.emoji')*

------
https://chatgpt.com/codex/tasks/task_e_68528caa1f5083309f2887e7b591f950