### PR TITLE
Add expandable code blocks plugin

### DIFF
--- a/material/plugins/code_expand/__init__.py
+++ b/material/plugins/code_expand/__init__.py
@@ -1,0 +1,1 @@
+"""Expandable code blocks plugin."""

--- a/material/plugins/code_expand/code-expand.css
+++ b/material/plugins/code_expand/code-expand.css
@@ -1,0 +1,11 @@
+.code-expandable { position: relative; }
+.code-expand-button {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  font-size: 0.75rem;
+}
+.code-expanded {
+  max-width: none !important;
+  overflow: auto;
+}

--- a/material/plugins/code_expand/code-expand.js
+++ b/material/plugins/code_expand/code-expand.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('pre > code').forEach(code => {
+    const pre = code.parentElement;
+    if (!pre) return;
+    if (pre.scrollWidth <= pre.clientWidth) return;
+
+    pre.classList.add('code-expandable');
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'code-expand-button';
+    btn.textContent = 'Expand';
+    btn.addEventListener('click', () => {
+      pre.classList.toggle('code-expanded');
+      btn.textContent = pre.classList.contains('code-expanded') ? 'Collapse' : 'Expand';
+    });
+    pre.insertBefore(btn, pre.firstChild);
+  });
+});

--- a/material/plugins/code_expand/config.py
+++ b/material/plugins/code_expand/config.py
@@ -1,0 +1,5 @@
+from mkdocs.config.base import Config
+from mkdocs.config.config_options import Type
+
+class CodeExpandConfig(Config):
+    enabled = Type(bool, default=True)

--- a/material/plugins/code_expand/plugin.py
+++ b/material/plugins/code_expand/plugin.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+from mkdocs.plugins import BasePlugin
+from mkdocs.utils import copy_file
+from mkdocs.config.defaults import MkDocsConfig
+
+from .config import CodeExpandConfig
+
+
+class CodeExpandPlugin(BasePlugin[CodeExpandConfig]):
+    def on_config(self, config: MkDocsConfig):
+        if not self.config.enabled:
+            return
+
+        self.script_name = os.path.join('assets', 'javascripts', 'code-expand.js')
+        self.style_name = os.path.join('assets', 'stylesheets', 'code-expand.css')
+        self.script_source = os.path.join(os.path.dirname(__file__), 'code-expand.js')
+        self.style_source = os.path.join(os.path.dirname(__file__), 'code-expand.css')
+
+        if self.script_name not in config.extra_javascript:
+            config.extra_javascript.append(self.script_name)
+        if self.style_name not in config.extra_css:
+            config.extra_css.append(self.style_name)
+
+    def on_post_build(self, *, config: MkDocsConfig):
+        if not self.config.enabled:
+            return
+        dest_script = os.path.join(config.site_dir, self.script_name)
+        dest_style = os.path.join(config.site_dir, self.style_name)
+        os.makedirs(os.path.dirname(dest_script), exist_ok=True)
+        os.makedirs(os.path.dirname(dest_style), exist_ok=True)
+        copy_file(self.script_source, dest_script)
+        copy_file(self.style_source, dest_style)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ Funding = "https://github.com/sponsors/squidfunk"
 "material/search" = "material.plugins.search.plugin:SearchPlugin"
 "material/social" = "material.plugins.social.plugin:SocialPlugin"
 "material/tags" = "material.plugins.tags.plugin:TagsPlugin"
+"material/code-expand" = "material.plugins.code_expand.plugin:CodeExpandPlugin"
 
 [project.entry-points."mkdocs.themes"]
 material = "material.templates"

--- a/src/plugins/code_expand/__init__.py
+++ b/src/plugins/code_expand/__init__.py
@@ -1,0 +1,1 @@
+"""Expandable code blocks plugin."""

--- a/src/plugins/code_expand/code-expand.css
+++ b/src/plugins/code_expand/code-expand.css
@@ -1,0 +1,11 @@
+.code-expandable { position: relative; }
+.code-expand-button {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  font-size: 0.75rem;
+}
+.code-expanded {
+  max-width: none !important;
+  overflow: auto;
+}

--- a/src/plugins/code_expand/code-expand.js
+++ b/src/plugins/code_expand/code-expand.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('pre > code').forEach(code => {
+    const pre = code.parentElement;
+    if (!pre) return;
+    if (pre.scrollWidth <= pre.clientWidth) return;
+
+    pre.classList.add('code-expandable');
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'code-expand-button';
+    btn.textContent = 'Expand';
+    btn.addEventListener('click', () => {
+      pre.classList.toggle('code-expanded');
+      btn.textContent = pre.classList.contains('code-expanded') ? 'Collapse' : 'Expand';
+    });
+    pre.insertBefore(btn, pre.firstChild);
+  });
+});

--- a/src/plugins/code_expand/config.py
+++ b/src/plugins/code_expand/config.py
@@ -1,0 +1,5 @@
+from mkdocs.config.base import Config
+from mkdocs.config.config_options import Type
+
+class CodeExpandConfig(Config):
+    enabled = Type(bool, default=True)

--- a/src/plugins/code_expand/plugin.py
+++ b/src/plugins/code_expand/plugin.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+from mkdocs.plugins import BasePlugin
+from mkdocs.utils import copy_file
+from mkdocs.config.defaults import MkDocsConfig
+
+from .config import CodeExpandConfig
+
+
+class CodeExpandPlugin(BasePlugin[CodeExpandConfig]):
+    def on_config(self, config: MkDocsConfig):
+        if not self.config.enabled:
+            return
+
+        self.script_name = os.path.join('assets', 'javascripts', 'code-expand.js')
+        self.style_name = os.path.join('assets', 'stylesheets', 'code-expand.css')
+        self.script_source = os.path.join(os.path.dirname(__file__), 'code-expand.js')
+        self.style_source = os.path.join(os.path.dirname(__file__), 'code-expand.css')
+
+        if self.script_name not in config.extra_javascript:
+            config.extra_javascript.append(self.script_name)
+        if self.style_name not in config.extra_css:
+            config.extra_css.append(self.style_name)
+
+    def on_post_build(self, *, config: MkDocsConfig):
+        if not self.config.enabled:
+            return
+        dest_script = os.path.join(config.site_dir, self.script_name)
+        dest_style = os.path.join(config.site_dir, self.style_name)
+        os.makedirs(os.path.dirname(dest_script), exist_ok=True)
+        os.makedirs(os.path.dirname(dest_style), exist_ok=True)
+        copy_file(self.script_source, dest_script)
+        copy_file(self.style_source, dest_style)


### PR DESCRIPTION
## Summary
- add new `code-expand` plugin to make wide code blocks expandable on click
- include JavaScript/CSS assets for toggling expansion
- register the plugin entry point in `pyproject.toml`

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68528e121c0c8330972990541f035e1e