### PR TITLE
Add expandable code block plugin

### DIFF
--- a/material/plugins/expand/__init__.py
+++ b/material/plugins/expand/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2016-2025 Martin Donath <martin.donath@squidfunk.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.

--- a/material/plugins/expand/assets/expand-code.css
+++ b/material/plugins/expand/assets/expand-code.css
@@ -1,0 +1,11 @@
+.md-expand-code{
+  position:absolute;
+  top:0;
+  right:0;
+  border:none;
+  background:transparent;
+  cursor:pointer;
+}
+pre.md-code--expanded{
+  max-width:none;
+}

--- a/material/plugins/expand/assets/expand-code.js
+++ b/material/plugins/expand/assets/expand-code.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded',()=>{
+  document.querySelectorAll('.md-typeset pre > code').forEach(code=>{
+    const pre=code.parentElement;
+    if(pre.scrollWidth>pre.clientWidth){
+      const btn=document.createElement('button');
+      btn.className='md-expand-code';
+      btn.title='Expand code';
+      btn.addEventListener('click',()=>{
+        pre.classList.toggle('md-code--expanded');
+      });
+      pre.insertBefore(btn,code);
+    }
+  });
+});

--- a/material/plugins/expand/config.py
+++ b/material/plugins/expand/config.py
@@ -1,0 +1,5 @@
+from mkdocs.config.config_options import Type
+from mkdocs.config.base import Config
+
+class ExpandCodeConfig(Config):
+    enabled = Type(bool, default=True)

--- a/material/plugins/expand/plugin.py
+++ b/material/plugins/expand/plugin.py
@@ -1,0 +1,25 @@
+import os
+from mkdocs.plugins import BasePlugin
+from mkdocs.utils import copy_file
+
+from .config import ExpandCodeConfig
+
+class ExpandCodePlugin(BasePlugin[ExpandCodeConfig]):
+    def on_config(self, config):
+        if not self.config.enabled:
+            return
+        config.extra_javascript.append('assets/javascripts/expand-code.js')
+        config.extra_css.append('assets/stylesheets/expand-code.css')
+
+    def on_post_build(self, *, config):
+        if not self.config.enabled:
+            return
+        assets = os.path.join(os.path.dirname(__file__), 'assets')
+        js_src = os.path.join(assets, 'expand-code.js')
+        css_src = os.path.join(assets, 'expand-code.css')
+        js_dst = os.path.join(config.site_dir, 'assets', 'javascripts', 'expand-code.js')
+        css_dst = os.path.join(config.site_dir, 'assets', 'stylesheets', 'expand-code.css')
+        os.makedirs(os.path.dirname(js_dst), exist_ok=True)
+        os.makedirs(os.path.dirname(css_dst), exist_ok=True)
+        copy_file(js_src, js_dst)
+        copy_file(css_src, css_dst)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ Funding = "https://github.com/sponsors/squidfunk"
 "material/search" = "material.plugins.search.plugin:SearchPlugin"
 "material/social" = "material.plugins.social.plugin:SocialPlugin"
 "material/tags" = "material.plugins.tags.plugin:TagsPlugin"
+"material/expand-code" = "material.plugins.expand.plugin:ExpandCodePlugin"
 
 [project.entry-points."mkdocs.themes"]
 material = "material.templates"

--- a/src/plugins/expand/__init__.py
+++ b/src/plugins/expand/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2016-2025 Martin Donath <martin.donath@squidfunk.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.

--- a/src/plugins/expand/assets/expand-code.css
+++ b/src/plugins/expand/assets/expand-code.css
@@ -1,0 +1,11 @@
+.md-expand-code{
+  position:absolute;
+  top:0;
+  right:0;
+  border:none;
+  background:transparent;
+  cursor:pointer;
+}
+pre.md-code--expanded{
+  max-width:none;
+}

--- a/src/plugins/expand/assets/expand-code.js
+++ b/src/plugins/expand/assets/expand-code.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded',()=>{
+  document.querySelectorAll('.md-typeset pre > code').forEach(code=>{
+    const pre=code.parentElement;
+    if(pre.scrollWidth>pre.clientWidth){
+      const btn=document.createElement('button');
+      btn.className='md-expand-code';
+      btn.title='Expand code';
+      btn.addEventListener('click',()=>{
+        pre.classList.toggle('md-code--expanded');
+      });
+      pre.insertBefore(btn,code);
+    }
+  });
+});

--- a/src/plugins/expand/config.py
+++ b/src/plugins/expand/config.py
@@ -1,0 +1,5 @@
+from mkdocs.config.config_options import Type
+from mkdocs.config.base import Config
+
+class ExpandCodeConfig(Config):
+    enabled = Type(bool, default=True)

--- a/src/plugins/expand/plugin.py
+++ b/src/plugins/expand/plugin.py
@@ -1,0 +1,25 @@
+import os
+from mkdocs.plugins import BasePlugin
+from mkdocs.utils import copy_file
+
+from .config import ExpandCodeConfig
+
+class ExpandCodePlugin(BasePlugin[ExpandCodeConfig]):
+    def on_config(self, config):
+        if not self.config.enabled:
+            return
+        config.extra_javascript.append('assets/javascripts/expand-code.js')
+        config.extra_css.append('assets/stylesheets/expand-code.css')
+
+    def on_post_build(self, *, config):
+        if not self.config.enabled:
+            return
+        assets = os.path.join(os.path.dirname(__file__), 'assets')
+        js_src = os.path.join(assets, 'expand-code.js')
+        css_src = os.path.join(assets, 'expand-code.css')
+        js_dst = os.path.join(config.site_dir, 'assets', 'javascripts', 'expand-code.js')
+        css_dst = os.path.join(config.site_dir, 'assets', 'stylesheets', 'expand-code.css')
+        os.makedirs(os.path.dirname(js_dst), exist_ok=True)
+        os.makedirs(os.path.dirname(css_dst), exist_ok=True)
+        copy_file(js_src, js_dst)
+        copy_file(css_src, css_dst)


### PR DESCRIPTION
## Summary
- create `expand-code` plugin for adding expandable code blocks
- package plugin assets and expose plugin entry point

## Testing
- `npm run check`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68528e121c0c8330972990541f035e1e