### PR TITLE
Add expandable code block assets

### DIFF
--- a/docs/assets/javascripts/code-expand.js
+++ b/docs/assets/javascripts/code-expand.js
@@ -1,0 +1,24 @@
+function initCodeExpand() {
+  document.querySelectorAll('pre > code').forEach(function(code) {
+    var pre = code.parentElement;
+    if (pre.scrollWidth > pre.clientWidth) {
+      pre.classList.add('code-expand');
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'code-expand-toggle';
+      btn.textContent = '\u2B48'; // unicode symbol for expand
+      btn.title = 'Expand';
+      btn.addEventListener('click', function() {
+        pre.classList.toggle('expanded');
+        btn.title = pre.classList.contains('expanded') ? 'Collapse' : 'Expand';
+      });
+      pre.insertBefore(btn, pre.firstChild);
+    }
+  });
+}
+
+if (document.readyState !== 'loading') {
+  initCodeExpand();
+} else {
+  document.addEventListener('DOMContentLoaded', initCodeExpand);
+}

--- a/docs/assets/stylesheets/code-expand.css
+++ b/docs/assets/stylesheets/code-expand.css
@@ -1,0 +1,23 @@
+/* Expandable code blocks */
+pre.code-expand {
+  position: relative;
+}
+pre.code-expand button.code-expand-toggle {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  padding: 0.2rem 0.4rem;
+  font-size: 0.75rem;
+  border: none;
+  border-radius: 2px;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color--lightest);
+  cursor: pointer;
+}
+pre.code-expand button.code-expand-toggle:focus {
+  outline: 2px solid var(--md-accent-fg-color);
+}
+pre.code-expand.expanded {
+  width: 100vw;
+  margin-left: calc(-50vw + 50%);
+}


### PR DESCRIPTION
## Summary
- add JS to toggle full width for overflowing code blocks
- add CSS styling for expand button

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685297aaac948330ac8fd0b92cabd92a